### PR TITLE
updating maximum primer length from 32 to 43

### DIFF
--- a/primers/primers.py
+++ b/primers/primers.py
@@ -9,7 +9,7 @@ from .off_targets import off_targets
 
 
 LEN_MIN = 15  # min length of the annealing portion of primers
-LEN_MAX = 32  # max length of the annealing portion of primers, based on IDT guidelines
+LEN_MAX = 43  # max length of the annealing portion of primers, originally 32 but wanted to use longer due to low GC content
 
 
 class Scoring(NamedTuple):


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the ArkeaBio Code Review Policy: https://docs.google.com/document/d/1yX6rkFrQQhdozEB8OBE9jWsQZgDMw3KS0DLd7MWPEAo/edit#heading=h.tgvpr2mcrxkb
     - 👷‍♀️ Create small PRs. 
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR updates the maximum primer length within the tool in order to enable longer primers to be designed in cases where the GC content of a target sequence is low.


## Jira Task
[CB-201](https://arkeabio.atlassian.net/browse/CB-201)

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📕 notebook(s)
- [ ] 🙅 no documentation needed

## Code Quality
- [x] 🎯 The code is properly formatted and adheres to the project's style guide
- [x] 🎯 The code runs without any errors or exceptions

## Compute Environment
Can be run locally

## Testing
Will be included as part of primer design tool
